### PR TITLE
create missing directories

### DIFF
--- a/execute.sh
+++ b/execute.sh
@@ -29,6 +29,9 @@ else
   fi
 fi
 
+# Create needed directories, if needed
+mkdir --parents $JAWSM_DIR/wat $JAWSM_DIR/wasm
+
 # Run the compiler
 if ! cat $1 | $COMPILER; then
   exit 100


### PR DESCRIPTION
### create missing directories - fix #3

This PR adds the needed _wat_  and _wasm_ folders, when using `./execute.sh`.
